### PR TITLE
fixing undefined variable $linkResultsFlag 

### DIFF
--- a/riak.php
+++ b/riak.php
@@ -367,6 +367,8 @@ class RiakMapReduce {
   function run($timeout=NULL) {
     $num_phases = count($this->phases);
 
+    $linkResultsFlag = FALSE;
+
     # If there are no phases, then just echo the inputs back to the user.
     if ($num_phases == 0) {
       $this->reduce(array("riak_kv_mapreduce", "reduce_identity"));


### PR DESCRIPTION
If $num_phases != 0 then $linkResultsFlag is undefined in line 403 and throws an E_NOTICE message: Notice: Undefined variable: linkResultsFlag in .../riak-php-client/riak.php on line 401

Repro code:

```
$client = new RiakClient();
$bucket = $client->bucket('stuff');

$mapFunc = 'function(value, keyData, arg) {
    if(value.key.indexOf("str") !== -1) return [value.key];
    return [];
}';

$result = $client->add($bucket->getName())->map($mapFunc)->reduce('Riak.reduceSort')->run();
```
