### PR TITLE
The second parameter of RiakMapReduce::add should be cast to a string

### DIFF
--- a/riak.php
+++ b/riak.php
@@ -261,7 +261,7 @@ class RiakMapReduce {
       else
         return $this->add_bucket($arg1);
     }
-    return $this->add_bucket_key_data($arg1, $arg2, $arg3);
+    return $this->add_bucket_key_data($arg1, (string) $arg2, $arg3);
   }
 
   /**


### PR DESCRIPTION
The second parameter of RiakMapReduce::add when not null should be forced to a sting when the key is an integer. 

Prior to this change, one would get the following error message:

An error occurred parsing the "inputs" field.
Unrecognized format of input element:
   ["mybucket",123,null]

Valid formats are:
   [Bucket, Key]
   [Bucket, Key, KeyData]
where Bucket and Key are strings
