### PR TITLE
alternative version of riak client (php5.3+) with curl-multi

### DIFF
--- a/unit_tests.php
+++ b/unit_tests.php
@@ -25,6 +25,7 @@ test("testDelete");
 test("testPrepareDelete");
 test("testSetBucketProperties");
 test("testPrepareSetBucketProperties");
+test("testBucketKeysWithCallback");
 test("testSiblings");
 test("testPrepareSiblings");
 
@@ -272,6 +273,20 @@ function testPrepareSetBucketProperties() {
   
   test_assert( $props['allow_mult'] == FALSE );
   test_assert( $props['n_val'] == 2 );
+}
+
+function testBucketKeysWithCallback() {
+  $client = new RiakClient(HOST, PORT);
+  $bucket = $client->bucket('bucket');
+  $ct = 0;
+  $callback = function( $key ) use ( & $ct ){
+    $ct++;
+    if( $ct > 1 ) return FALSE;
+  };
+  
+  $bucket->getKeys( $callback );
+  
+  test_assert( $ct > 0 );
 }
 
 


### PR DESCRIPTION
sometimes the client has a series of parallel requests to send to riak. The client has been refactored to be able to issue multiple parallel http requests using a small http wrapper around curl multi handles. It uses closures to wrap up what happens after the http request is finished and package them in the response. That way you can either issue the request immediately as it currently works in serial order, or defer the actual execution until later.

The code is 100% compatible with the current client API, but has a few additional method hooks in to allow the developer to grap the http request and attach it to a http pool for processing. all of these methods are prefixed with 'prepare_' so it is easy to recognize and they match up with the name of the method they allow you to capture. 

Example:

$http_request = $bucket->newObject('foo', rand())->prepare_store();
$http_response = $http_request->send();
$result = $http_response->result;

this is equivalent to:
$result = $bucket->newObject('foo', rand())->store();

However it allows me to attach that request to a pool and run many requests in parallel:

$pool = $client->pool();
$requests[] = $pool->add( $bucket->newObject('foo', rand())->prepare_store() );
$requests[] = $pool->add( $bucket->newObject('bar', rand())->prepare_store() );
$pool->finish();

$results = array();

foreach( $requests as $request ){
  $results[] = $request->response->result;
}
