### PR TITLE
Explicitly set content type for MapReduce requests.

### DIFF
--- a/riak.php
+++ b/riak.php
@@ -478,7 +478,7 @@ class RiakMapReduce {
     
     # Do the request...
     $url = "http://" . $this->client->host . ":" . $this->client->port . "/" . $this->client->mapred_prefix;
-    $response = RiakUtils::httpRequest('POST', $url, array(), $content);
+    $response = RiakUtils::httpRequest('POST', $url, array('Content-type: application/json'), $content);
     $result = json_decode($response[1]);
 
     # If the last phase is NOT a link phase, then return the result.


### PR DESCRIPTION
MapReduce requests explicitly require content type set to fix
a XSRF issue.
