### PR TITLE
Incorrect comment on README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ or
 ## Fetching Objects ##
 Objects can be retrieved from a bucket using the RiakBucket::get() method
 
-    # Save the object to Riak
+    # Retrieve the object from a bucket
     $person = $bucket->get('riak_developer_1');
 
 This method returns a [RiakObject](http://basho.github.com/riak-php-client/class_riak_object.html)


### PR DESCRIPTION
On the Fetching Objects section of the README.md file one example has an incorrect comment:

``` php
# Save the object to Riak
$person = $bucket->get('riak_developer_1');
```

Changed it to

``` php
# Retrieve the object from a bucket
$person = $bucket->get('riak_developer_1');
```
