### PR TITLE
Handling for bad search requests

### DIFF
--- a/src/Riak/Command/Search/Response.php
+++ b/src/Riak/Command/Search/Response.php
@@ -35,7 +35,7 @@ class Response extends \Basho\Riak\Command\Response
         parent::__construct($statusCode, $headers, $body);
 
         // make sure body is not only whitespace
-        if (trim($body)) {
+        if (trim($body) && $this->statusCode != 400) {
             $this->results = json_decode($body);
             foreach ($this->results->response->docs as $doc) {
                 $this->docs[] = new Doc($doc);
@@ -45,7 +45,7 @@ class Response extends \Basho\Riak\Command\Response
 
     public function getNumFound()
     {
-        return $this->results->response->numFound;
+        return !empty($this->results->response->numFound) ? $this->results->response->numFound : 0;
     }
 
     public function getDocs()

--- a/src/Riak/Command/Search/Response.php
+++ b/src/Riak/Command/Search/Response.php
@@ -35,8 +35,8 @@ class Response extends \Basho\Riak\Command\Response
         parent::__construct($statusCode, $headers, $body);
 
         // make sure body is not only whitespace
-        if (trim($body) && in_array($this->statusCode, [200,204])) {
-            $this->results = json_decode($body);
+        $this->results = in_array($this->statusCode, [200,204]) ? json_decode($body) : null;
+        if ($this->results) {
             foreach ($this->results->response->docs as $doc) {
                 $this->docs[] = new Doc($doc);
             }

--- a/src/Riak/Command/Search/Response.php
+++ b/src/Riak/Command/Search/Response.php
@@ -35,7 +35,7 @@ class Response extends \Basho\Riak\Command\Response
         parent::__construct($statusCode, $headers, $body);
 
         // make sure body is not only whitespace
-        if (trim($body) && $this->statusCode != 400) {
+        if (trim($body) && in_array($this->statusCode, [200,204])) {
             $this->results = json_decode($body);
             foreach ($this->results->response->docs as $doc) {
                 $this->docs[] = new Doc($doc);

--- a/tests/functional/SearchOperationsTest.php
+++ b/tests/functional/SearchOperationsTest.php
@@ -232,6 +232,27 @@ class SearchOperationsTest extends TestCase
     }
 
     /**
+     * Tests handling of a badly formed query
+     *
+     * @depends      testAssociateIndex
+     * @dataProvider getLocalNodeConnection
+     *
+     * @param $riak \Basho\Riak
+     */
+    public function testBadSearch($riak)
+    {
+        $response = (new Command\Builder\Search\FetchObjects($riak))
+            ->withIndexName(static::INDEX)
+            ->withQuery('ffffff')
+            ->build()
+            ->execute();
+
+        $this->assertEquals('400', $response->getStatusCode(), $response->getBody());
+        $this->assertEmpty($response->getNumFound());
+        $this->assertEmpty($response->getDocs());
+    }
+
+    /**
      * @depends      testSearch
      * @dataProvider getLocalNodeConnection
      *


### PR DESCRIPTION
I added code to abort the processing of the result set when a 400 status code has been returned to account for issue #103 (CLIENTS-597). Added a new test for this case.