### PR TITLE
Fixed error in example code (inline docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $command = (new Command\Builder\StoreObject($riak))
     ->build();
     
 // Receive a response object
-$response = $command->execute($command);
+$response = $command->execute();
 
 // Retrieve the Location of our newly stored object from the Response object
 $object_location = $response->getLocation();

--- a/src/Riak.php
+++ b/src/Riak.php
@@ -23,7 +23,7 @@ use Basho\Riak\Node;
  *   ->buildLocation('username', 'users')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user = $response->getObject();
  * </code>

--- a/src/Riak/Command/Builder/DeleteObject.php
+++ b/src/Riak/Command/Builder/DeleteObject.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  * ->buildLocation('username', 'users')
  * ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  * </code>
  *
  * @author Christopher Mancini <cmancini at basho d0t com>

--- a/src/Riak/Command/Builder/FetchBucketProperties.php
+++ b/src/Riak/Command/Builder/FetchBucketProperties.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($order_id, 'online_orders', 'sales_maps')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $map = $response->getMap();
  * </code>

--- a/src/Riak/Command/Builder/FetchCounter.php
+++ b/src/Riak/Command/Builder/FetchCounter.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($user_name, 'user_visit_count', 'visit_counters')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $counter = $response->getCounter();
  * </code>

--- a/src/Riak/Command/Builder/FetchMap.php
+++ b/src/Riak/Command/Builder/FetchMap.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($order_id, 'online_orders', 'sales_maps')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $map = $response->getMap();
  * </code>

--- a/src/Riak/Command/Builder/FetchObject.php
+++ b/src/Riak/Command/Builder/FetchObject.php
@@ -13,7 +13,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($user_id, 'users', 'default')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user = $response->getObject();
  * </code>

--- a/src/Riak/Command/Builder/FetchPreflist.php
+++ b/src/Riak/Command/Builder/FetchPreflist.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($order_id, 'online_orders', 'sales')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  * </code>
  *
  * @author Christopher Mancini <cmancini at basho d0t com>

--- a/src/Riak/Command/Builder/FetchSet.php
+++ b/src/Riak/Command/Builder/FetchSet.php
@@ -12,7 +12,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($user_id, 'email_subscriptions', 'user_preferences')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $set = $response->getSet();
  * </code>

--- a/src/Riak/Command/Builder/IncrementCounter.php
+++ b/src/Riak/Command/Builder/IncrementCounter.php
@@ -13,7 +13,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($user_name, 'user_visit_count', 'visit_counters')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $counter = $response->getCounter();
  * </code>

--- a/src/Riak/Command/Builder/Ping.php
+++ b/src/Riak/Command/Builder/Ping.php
@@ -13,7 +13,7 @@ use Basho\Riak\Command;
  *   ->buildLocation($user_id, 'users', 'default')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user = $response->getObject();
  * </code>

--- a/src/Riak/Command/Builder/QueryIndex.php
+++ b/src/Riak/Command/Builder/QueryIndex.php
@@ -13,7 +13,7 @@ use Basho\Riak\Command;
  *   ->withIndex('users_name', 'Knuth')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $index_results = $response->getIndexResults();
  * </code>

--- a/src/Riak/Command/Builder/Search/AssociateIndex.php
+++ b/src/Riak/Command/Builder/Search/AssociateIndex.php
@@ -13,7 +13,7 @@ use Basho\Riak\Command;
  *   ->buildBucket('users')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user_location = $response->getLocation();
  * </code>

--- a/src/Riak/Command/Builder/Search/DissociateIndex.php
+++ b/src/Riak/Command/Builder/Search/DissociateIndex.php
@@ -14,7 +14,7 @@ use Basho\Riak\Command;
  *   ->buildBucket('users')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user_location = $response->getLocation();
  * </code>

--- a/src/Riak/Command/Builder/StoreObject.php
+++ b/src/Riak/Command/Builder/StoreObject.php
@@ -14,7 +14,7 @@ use Basho\Riak\Command;
  *   ->buildBucket('users')
  *   ->build();
  *
- * $response = $command->execute($command);
+ * $response = $command->execute();
  *
  * $user_location = $response->getLocation();
  * </code>


### PR DESCRIPTION
The docs suggest passing the argument $command to $command->execute() like this:

```
$command->execute($command);
```
That's obviously not correct. It must be 
```
$command->execute();
```
