### PR TITLE
Using isset() to check if bucket props exist to avoid PHP notice

### DIFF
--- a/src/Riak/Api/Http.php
+++ b/src/Riak/Api/Http.php
@@ -640,7 +640,7 @@ class Http extends Api implements ApiInterface
                 $bucket = null;
                 $modified = $this->getResponseHeader(static::LAST_MODIFIED_KEY, '');
                 $properties = json_decode($body, true);
-                if ($properties && $this->command->getBucket()) {
+                if (isset($properties['props']) && $this->command->getBucket()) {
                     $bucket = new Bucket($this->command->getBucket()->getName(), $this->command->getBucket()->getType(), $properties['props']);
                 }
                 $response = new Command\Bucket\Response($this->success, $this->statusCode, $this->error, $bucket, $modified);


### PR DESCRIPTION
If "props" is not set, you'll get the notice "Undefined index: props" otherwise.

Example: Adding an index returns with {"search_index":"schema does not exist"} if a schema does not exist. Actually, the client library should return an error in this case, if the HTTP status code was properly set by Riak. Maybe that's another bug?