### PR TITLE
Added getData() method to Basho\Riak\Search\Doc

### DIFF
--- a/src/Riak/Search/Doc.php
+++ b/src/Riak/Search/Doc.php
@@ -44,16 +44,32 @@ class Doc
         $this->data = $data;
     }
 
+    /**
+     * Returns bucket location
+     *
+     * @return Location
+     */
     public function getLocation()
     {
         return new Location($this->_yz_rk, new Bucket($this->_yz_rb, $this->_yz_rt));
     }
 
+    /**
+     * Returns a single value from Solr result document
+     *
+     * @param string $name
+     * @return mixed
+     */
     public function __get($name)
     {
         return $this->data->{$name};
     }
 
+    /**
+     * Returns all values as array from Solr result document
+     *
+     * @return array
+     */
     public function getData()
     {
         return (array)$this->data;

--- a/src/Riak/Search/Doc.php
+++ b/src/Riak/Search/Doc.php
@@ -45,7 +45,7 @@ class Doc
     }
 
     /**
-     * Returns bucket location
+     * Returns object location
      *
      * @return Location
      */

--- a/src/Riak/Search/Doc.php
+++ b/src/Riak/Search/Doc.php
@@ -53,4 +53,9 @@ class Doc
     {
         return $this->data->{$name};
     }
+
+    public function getData()
+    {
+        return (array)$this->data;
+    }
 }

--- a/tests/unit/Riak/Search/DocTest.php
+++ b/tests/unit/Riak/Search/DocTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Basho\Tests\Riak\Search;
+
+use Basho\Riak\Search\Doc;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Search result document test
+ *
+ * @author Michael Mayer <michael@lastzero.net>
+ */
+class DocTest extends TestCase
+{
+    /**
+     * @var Doc
+     */
+    protected $doc;
+
+    public function setUp()
+    {
+        $data = new \stdClass();
+        $data->_yz_id = '1*tests*test*5*39';
+        $data->_yz_rk = '5';
+        $data->_yz_rt = 'tests';
+        $data->_yz_rb = 'test';
+        $data->foo = 'bar';
+        $data->_status = 200;
+        $this->doc = new Doc($data);
+    }
+
+    public function testGetLocation()
+    {
+        $result = $this->doc->getLocation();
+        $this->assertInstanceOf('\Basho\Riak\Location', $result);
+        $this->assertInstanceOf('\Basho\Riak\Bucket', $result->getBucket());
+        $this->assertEquals('tests', $result->getBucket()->getType());
+        $this->assertEquals('test', $result->getBucket()->getName());
+        $this->assertEquals('5', $result->getKey());
+    }
+
+    public function testGetData()
+    {
+        $result = $this->doc->getData();
+        $this->assertInternalType('array', $result);
+        $this->assertEquals('bar', $result['foo']);
+        $this->assertEquals(200, $result['_status']);
+    }
+}

--- a/tests/unit/Riak/Search/DocTest.php
+++ b/tests/unit/Riak/Search/DocTest.php
@@ -46,4 +46,10 @@ class DocTest extends TestCase
         $this->assertEquals('bar', $result['foo']);
         $this->assertEquals(200, $result['_status']);
     }
+
+    public function testMagicGetter()
+    {
+        $this->assertEquals('bar', $this->doc->foo);
+        $this->assertEquals(200, $this->doc->_status);
+    }
 }


### PR DESCRIPTION
See **Basho\Riak\Search\Doc does not allow to fetch all values returned by Solr #117 (CLIENTS-683) (CLIENTS-754)**

Note that getData() returns an array (see issue comment). I also added tests and inline documentation.