### PR TITLE
Do not encode binary/base64 command object

### DIFF
--- a/src/Riak/Command/Object.php
+++ b/src/Riak/Command/Object.php
@@ -45,6 +45,8 @@ abstract class Object extends Command
 
         if (in_array($this->object->getContentType(), ['application/json', 'text/json'])) {
             return json_encode($data);
+        }elseif (in_array($this->object->getContentEncoding(), ['binary', 'base64'])) {
+            return $data;
         }
 
         return rawurlencode($data);


### PR DESCRIPTION
Proposed fix for #122 (CLIENTS-698) (CLIENTS-918) - Not encoding binary data before submission to Riak.