### PR TITLE
Update tests to handle RiakTS 1.4 changes.

### DIFF
--- a/tests/TimeSeriesTrait.php
+++ b/tests/TimeSeriesTrait.php
@@ -35,7 +35,7 @@ trait TimeSeriesTrait
 
     protected static function populateKey()
     {
-        static::$now = new \DateTime("@1443806900");
+        static::$now = new \DateTime("@1443816900");
 
         static::$key = [
             (new Cell("region"))->setValue("South Atlantic"),

--- a/tests/functional/TimeSeriesOperationsTest.php
+++ b/tests/functional/TimeSeriesOperationsTest.php
@@ -75,7 +75,7 @@ class TimeSeriesOperationsTest extends TestCase
         $this->assertEquals('200', $response->getCode(), $response->getMessage());
         $this->assertNotEmpty($response->getResults());
         $this->assertCount(7, $response->getResults());
-        $this->assertCount(5, $response->getResult());
+        $this->assertGreaterThanOrEqual(5, $response->getResult());
     }
 
     public function testFetchRowNotFound()

--- a/tests/unit/Riak/Command/Builder/TimeSeries/DeleteRowTest.php
+++ b/tests/unit/Riak/Command/Builder/TimeSeries/DeleteRowTest.php
@@ -43,7 +43,7 @@ class DeleteRowTest extends TestCase
 
         // change the key and reuse builder to create new command
         $key = static::$key;
-        $key[2]->setTimestampValue(1443806901);
+        $key[2]->setTimestampValue(1443816901);
         $command = $builder->atKey($key)->build();
 
         $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806901", implode("/", $command->getData()));

--- a/tests/unit/Riak/Command/Builder/TimeSeries/DeleteRowTest.php
+++ b/tests/unit/Riak/Command/Builder/TimeSeries/DeleteRowTest.php
@@ -39,13 +39,13 @@ class DeleteRowTest extends TestCase
         $this->assertInstanceOf('Basho\Riak\Command\TimeSeries\Delete', $command);
         $this->assertEquals(static::$table, $command->getTable());
         $this->assertEquals(static::$key, $command->getData());
-        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806900", implode("/", $command->getData()));
+        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443816900", implode("/", $command->getData()));
 
         // change the key and reuse builder to create new command
         $key = static::$key;
         $key[2]->setTimestampValue(1443816901);
         $command = $builder->atKey($key)->build();
 
-        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806901", implode("/", $command->getData()));
+        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443816901", implode("/", $command->getData()));
     }
 }

--- a/tests/unit/Riak/Command/Builder/TimeSeries/FetchRowTest.php
+++ b/tests/unit/Riak/Command/Builder/TimeSeries/FetchRowTest.php
@@ -43,7 +43,7 @@ class FetchRowTest extends TestCase
 
         // change the key and reuse builder to create new command
         $key = static::$key;
-        $key[2]->setTimestampValue(1443806901);
+        $key[2]->setTimestampValue(1443816901);
         $command = $builder->atKey($key)->build();
 
         $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806901", implode("/", $command->getData()));

--- a/tests/unit/Riak/Command/Builder/TimeSeries/FetchRowTest.php
+++ b/tests/unit/Riak/Command/Builder/TimeSeries/FetchRowTest.php
@@ -39,13 +39,13 @@ class FetchRowTest extends TestCase
         $this->assertInstanceOf('Basho\Riak\Command\TimeSeries\Fetch', $command);
         $this->assertEquals(static::$table, $command->getTable());
         $this->assertEquals(static::$key, $command->getData());
-        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806900", implode("/", $command->getData()));
+        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443816900", implode("/", $command->getData()));
 
         // change the key and reuse builder to create new command
         $key = static::$key;
         $key[2]->setTimestampValue(1443816901);
         $command = $builder->atKey($key)->build();
 
-        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443806901", implode("/", $command->getData()));
+        $this->assertEquals("region/South%20Atlantic/state/South%20Carolina/time/1443816901", implode("/", $command->getData()));
     }
 }


### PR DESCRIPTION
Cell descriptions will include more fields than the original 5 going forward, so I updated the assertion to be >= making it backwards compatible. Also changed test timestamp due to key conflict with other tests.