### PR TITLE
Fix for binary content

### DIFF
--- a/src/Riak/Command/Object.php
+++ b/src/Riak/Command/Object.php
@@ -47,7 +47,7 @@ abstract class Object extends Command
             return json_encode($data);
         }
 
-        return rawurlencode($data);
+        return $data;
     }
 
     public function getDecodedData($data, $contentType)
@@ -61,7 +61,7 @@ abstract class Object extends Command
             return json_decode($data, $decodeAsAssociative);
         }
 
-        return rawurldecode($data);
+        return $data;
     }
 
     public function getData()


### PR DESCRIPTION
There is a problem with images and documents when Command\Object use rawurlencode to encode data.