### PR TITLE
Internal Server Error Handling for HTTP API

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
         </testsuite>
         <testsuite name="Scenario Tests">
             <directory>tests/scenario</directory>
-            <exclude>tests/scenario/InternalServerError.php</exclude>
+            <exclude>tests/scenario/InternalServerErrorTest.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
         </testsuite>
         <testsuite name="Scenario Tests">
             <directory>tests/scenario</directory>
+            <exclude>tests/scenario/InternalServerError.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Riak/Api/Http.php
+++ b/src/Riak/Api/Http.php
@@ -650,6 +650,11 @@ class Http extends Api implements ApiInterface
             $location = Location::fromString($this->getResponseHeader('Location'));
         }
 
+        if ($this->statusCode == 500) {
+            $this->success = false;
+            $this->error = $body;
+        }
+
         switch (get_class($this->command)) {
             case 'Basho\Riak\Command\Bucket\Store':
             case 'Basho\Riak\Command\Bucket\Fetch':

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     const MAP_BUCKET_TYPE = 'phptest_maps';
     const SET_BUCKET_TYPE = 'phptest_sets';
     const LEVELDB_BUCKET_TYPE = 'phptest_leveldb';
+    const BITCASK_BUCKET_TYPE = 'bitcask';
 
     /**
      * @var \Basho\Riak|null

--- a/tests/scenario/InternalServerErrorTest.php
+++ b/tests/scenario/InternalServerErrorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Basho\Tests;
+
+use Basho\Riak;
+use Basho\Riak\Command;
+
+/**
+ * Scenario tests for when an internal server error occurs
+ *
+ * @author Christopher Mancini <cmancini at basho d0t com>
+ */
+class InternalServerErrorTest extends TestCase
+{
+    /**
+     * Currently not executable on any Riak instance configured for multi-backend
+     * @expectedException \Basho\Riak\Exception
+     */
+    public function testQueryInvalidIndex()
+    {
+        $command = (new Command\Builder\QueryIndex(static::$riak))
+            ->buildBucket('Students', static::BITCASK_BUCKET_TYPE)
+            ->withIndexName('index_not_found_int')
+            ->withScalarValue(5)
+            ->build();
+
+        $command->execute();
+    }
+}


### PR DESCRIPTION
Add handling for Internal Server Errors (500 status code) to the HTTP API bridge class. Fixes #125 (CLIENTS-704) (CLIENTS-927) 